### PR TITLE
Fix: Crash on ios if photo url is not valid to make the request

### DIFF
--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -159,7 +159,14 @@
     MerryPhoto* currentPhoto = [self.dataSource.photos objectAtIndex:current];
     MerryPhotoData* d = self.reactPhotos[current];
 
-    [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:d.source.request
+    NSURLRequest *request = d.source.request;
+    bool requestValid = [NSURLConnection canHandleRequest:request];
+
+    if (!requestValid) {
+        return;
+    }
+
+    [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:request
         size:d.source.size
         scale:d.source.scale
         clipped:YES


### PR DESCRIPTION
Tracelog from Crashlytics:
```
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x1c1d1496c __exceptionPreprocess
1  libobjc.A.dylib                0x1c1a2d028 objc_exception_throw
2  CoreFoundation                 0x1c1d6d500 -[__NSCFString characterAtIndex:].cold.1
3  CoreFoundation                 0x1c1d77350 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:].cold.5
4  CoreFoundation                 0x1c1bfb540 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
5  CoreFoundation                 0x1c1becca4 +[NSDictionary dictionaryWithObjects:forKeys:count:]
6  MyNeveoMobile                  0x104f4a458 -[MerryPhotoView onNavigateToPhoto:Index:] + 241 (MerryPhotoView.m:241)
7  MyNeveoMobile                  0x104f49e7c __29-[MerryPhotoView showViewer:]_block_invoke + 146 (MerryPhotoView.m:146)
8  libdispatch.dylib              0x1c19b8b7c _dispatch_call_block_and_release
9  libdispatch.dylib              0x1c19b9fd8 _dispatch_client_callout
10 libdispatch.dylib              0x1c19c5cc8 _dispatch_main_queue_callback_4CF
11 CoreFoundation                 0x1c1c8fcc8 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
12 CoreFoundation                 0x1c1c8aa24 __CFRunLoopRun
13 CoreFoundation                 0x1c1c89f40 CFRunLoopRunSpecific
14 GraphicsServices               0x1cbf07534 GSEventRunModal
15 UIKitCore                      0x1c5e02a60 UIApplicationMain
16 MyNeveoMobile                  0x104e280c8 main + 7 (main.m:7)
17 libdyld.dylib                  0x1c1b08e18 start
```

I've added condition to check if request is valid for NSURLConnection.