### PR TITLE
set NYTPhotoViewer podspec dependency to 2.0.0

### DIFF
--- a/MerryPhotoViewer.podspec
+++ b/MerryPhotoViewer.podspec
@@ -14,7 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
-  s.dependency "NYTPhotoViewer"
-
+  s.dependency "NYTPhotoViewer", '~> 2.0.0'
 end


### PR DESCRIPTION
First, thank you for this library, it works very well!

The PR fixes this:
- there's no version specified for `NYTPhotoViewer` in `podspec`.
- on upgrade to the latest version (`"NYTPhotoViewer", '~> 4.0.0'`), the library breaks - it opens the viewer twice (2 viewers on top of each other, 2nd one having the progress count wrong `count/0`)
- this sets the dep version to `"NYTPhotoViewer", '~> 2.0.0'`
- removes `React` dep since it's already there in `RN >0.60`