### PR TITLE
add React podspec dependency back

### DIFF
--- a/MerryPhotoViewer.podspec
+++ b/MerryPhotoViewer.podspec
@@ -15,6 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "NYTPhotoViewer"
-
+  s.dependency "NYTPhotoViewer", '2.0.0'
 end


### PR DESCRIPTION
@bang88 Apparently, it doesn't compile without React dep. Adding it back.
Sorry about that