### PR TITLE
Fixed crash on iPad when try to share a photo

### DIFF
--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -253,8 +253,13 @@
 }
 - (void)displayActivityViewController:(UIActivityViewController*)controller animated:(BOOL)animated
 {
-
-    [[self getRootView] presentViewController:controller animated:animated completion:nil];
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        [[self getRootView] presentViewController:controller animated:animated completion:nil];
+    }
+    else {
+        UIPopoverController *popup = [[UIPopoverController alloc] initWithContentViewController:controller];
+        [popup presentPopoverFromRect:CGRectMake([self getRootView].view.frame.size.width/2, [self getRootView].view.frame.size.height/2, 0, 0)inView:[self getRootView].view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+    }
 }
 - (BOOL)photosViewController:(NYTPhotosViewController*)photosViewController handleLongPressForPhoto:(id<NYTPhoto>)photo withGestureRecognizer:(UILongPressGestureRecognizer*)longPressGestureRecognizer
 {


### PR DESCRIPTION
# Why

Fixes https://github.com/merryjs/photo-viewer/issues/118

## Before:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/870365/86928208-e59eca00-c0f9-11ea-81e4-d91d0f23731d.gif)

## After:
![ezgif com-resize](https://user-images.githubusercontent.com/870365/88468723-36aa0e80-cead-11ea-8a7a-22421aa46190.gif)
