### PR TITLE
[iOS] Call onDismiss After Saving Media Locally

### DIFF
--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -191,6 +191,16 @@
 {
     return nil;
 }
+- (void)photosViewController:(NYTPhotosViewController *)photosViewController actionCompletedWithActivityType:(NSString *)activityType {
+    if (self.hideStatusBar) {
+        [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:NO];
+    }
+
+    if (self.onDismiss) {
+        self.onDismiss(nil);
+    }
+    [self clean];
+}
 
 /**
  Customize title display


### PR DESCRIPTION
This fixes #120.

When a user saves a media object to their local device using the share action sheet, the viewer gets dismissed without actually calling the `onDismiss` callback (along with `clean`). For us, this caused our app to get stuck in a navigation state that made the app unresponsive.