### PR TITLE
Fix iOS gif only display first frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,6 @@ const photos = [
 
 For complete documentation please see https://merryjs.github.io/photo-viewer/interfaces/merryphotoviewporps.html
 
-## Known issues
-
-- IOS not support gif well when using imageLoader Please see https://github.com/facebook/react-native/issues/15427 any help are welcome. at this moment gif image on ios platform are only display the first frame and no animation.
-
 ## LICENSE
 
 ```

--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -1,6 +1,7 @@
 //  Created by react-native-create-bridge
 #import "MerryPhotoView.h"
 #import <React/RCTImageLoader.h>
+#import <React/RCTAnimatedImage.h>
 #import <Foundation/Foundation.h>
 
 @implementation MerryPhotoView {
@@ -171,8 +172,20 @@
         completionBlock:^(NSError* error, UIImage* image) {
             if (image) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-
-                    currentPhoto.image = image;
+                	// https://github.com/merryjs/photo-viewer/issues/11
+                	// we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
+                    if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
+                        RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
+                        NSMutableArray *imageList = [@[] mutableCopy];
+                        NSTimeInterval duration = 0;
+                        for (int i = 0; i < [animatedImage animatedImageFrameCount]; i ++) {
+                            [imageList addObject:[animatedImage animatedImageFrameAtIndex:i]];
+                            duration += [animatedImage animatedImageDurationAtIndex:i];
+                        }
+                        currentPhoto.image = [UIImage animatedImageWithImages:imageList duration:duration];
+                    } else {
+                        currentPhoto.image = image;
+                    }
 
                     [photosViewController updatePhoto:currentPhoto];
 

--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -173,7 +173,7 @@
             if (image) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // https://github.com/merryjs/photo-viewer/issues/11
-                    // we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
+                    // We convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
                     if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
                         RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
                         NSMutableArray *imageList = [@[] mutableCopy];

--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -172,20 +172,20 @@
         completionBlock:^(NSError* error, UIImage* image) {
             if (image) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                	// https://github.com/merryjs/photo-viewer/issues/11
-                	// we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
-                    if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
-                        RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
-                        NSMutableArray *imageList = [@[] mutableCopy];
-                        NSTimeInterval duration = 0;
-                        for (int i = 0; i < [animatedImage animatedImageFrameCount]; i ++) {
-                            [imageList addObject:[animatedImage animatedImageFrameAtIndex:i]];
-                            duration += [animatedImage animatedImageDurationAtIndex:i];
-                        }
-                        currentPhoto.image = [UIImage animatedImageWithImages:imageList duration:duration];
-                    } else {
-                        currentPhoto.image = image;
-                    }
+					// https://github.com/merryjs/photo-viewer/issues/11
+					// we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
+					if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
+					    RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
+					    NSMutableArray *imageList = [@[] mutableCopy];
+					    NSTimeInterval duration = 0;
+					    for (int i = 0; i < [animatedImage animatedImageFrameCount]; i ++) {
+					        [imageList addObject:[animatedImage animatedImageFrameAtIndex:i]];
+					        duration += [animatedImage animatedImageDurationAtIndex:i];
+					    }
+					    currentPhoto.image = [UIImage animatedImageWithImages:imageList duration:duration];
+					} else {
+					    currentPhoto.image = image;
+					}
 
                     [photosViewController updatePhoto:currentPhoto];
 

--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -174,7 +174,7 @@
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // https://github.com/merryjs/photo-viewer/issues/11
                     // We convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
-                    if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
+                    if ([image isKindOfClass:[RCTAnimatedImage class]]) {
                         RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
                         NSMutableArray *imageList = [@[] mutableCopy];
                         NSTimeInterval duration = 0;

--- a/ios/MerryPhotoView.m
+++ b/ios/MerryPhotoView.m
@@ -172,20 +172,20 @@
         completionBlock:^(NSError* error, UIImage* image) {
             if (image) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-					// https://github.com/merryjs/photo-viewer/issues/11
-					// we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
-					if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
-					    RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
-					    NSMutableArray *imageList = [@[] mutableCopy];
-					    NSTimeInterval duration = 0;
-					    for (int i = 0; i < [animatedImage animatedImageFrameCount]; i ++) {
-					        [imageList addObject:[animatedImage animatedImageFrameAtIndex:i]];
-					        duration += [animatedImage animatedImageDurationAtIndex:i];
-					    }
-					    currentPhoto.image = [UIImage animatedImageWithImages:imageList duration:duration];
-					} else {
-					    currentPhoto.image = image;
-					}
+                    // https://github.com/merryjs/photo-viewer/issues/11
+                    // we convert RCTAnimatedImage to UIAnimatedImage so that UIImageView can display gif
+                    if ([image isKindOfClass:NSClassFromString(@"RCTAnimatedImage")]) {
+                        RCTAnimatedImage *animatedImage = (RCTAnimatedImage *)image;
+                        NSMutableArray *imageList = [@[] mutableCopy];
+                        NSTimeInterval duration = 0;
+                        for (int i = 0; i < [animatedImage animatedImageFrameCount]; i ++) {
+                            [imageList addObject:[animatedImage animatedImageFrameAtIndex:i]];
+                            duration += [animatedImage animatedImageDurationAtIndex:i];
+                        }
+                        currentPhoto.image = [UIImage animatedImageWithImages:imageList duration:duration];
+                    } else {
+                        currentPhoto.image = image;
+                    }
 
                     [photosViewController updatePhoto:currentPhoto];
 


### PR DESCRIPTION
Fix https://github.com/merryjs/photo-viewer/issues/11

### Before


https://user-images.githubusercontent.com/20135674/219368439-326ecd71-4cc1-486f-9a11-69b8aad78b89.mp4

### Change
Because the gif data encoded by RCTAnimatedImage can only be displayed by RCTImageView, so we convert it to UIAnimatedImage so that UIImageView can also display it


### After


https://user-images.githubusercontent.com/20135674/219368473-19c1c5ff-da66-4c83-b696-357cfb160f40.mp4



